### PR TITLE
Advertise support for GNOME 46

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,8 @@
     "name" : "Screen Rotator",
     "description" : "Allows you to quickly rotate the screen.",
     "shell-version" : [
-        "45"
+        "45",
+        "46"
     ],
     "url" : "https://github.com/Bronzdragon/screen-rotator",
     "uuid" : "screen-rotator@bronzdragon.github.io",


### PR DESCRIPTION
It seems to work (as tested under Wayland session) with both of the panel rotation buttons doing the expected things.

The rotation is reset back upon reboot/relogin (unlike changing display orientation on `gnome-control-center`) but I assume that's how it works even on GNOME 45 with the already published version of this extension :)